### PR TITLE
New getter/setter pair "xpPoints" to read/modify player's xp points

### DIFF
--- a/src/main/java/youyihj/zenutils/api/player/ZenUtilsPlayer.java
+++ b/src/main/java/youyihj/zenutils/api/player/ZenUtilsPlayer.java
@@ -62,6 +62,20 @@ public class ZenUtilsPlayer {
     }
 
     @ZenMethod
+    @ZenGetter("xpPoints")
+    public static int getXpPoints(IPlayer player) {
+        return CraftTweakerMC.getPlayer(player).experienceTotal;
+    }
+
+    @ZenMethod
+    @ZenSetter("xpPoints")
+    public static void setXpPoints(IPlayer player, int xpPoints) {
+        EntityPlayer mcPlayer = CraftTweakerMC.getPlayer(player);
+        mcPlayer.addExperienceLevel(-mcPlayer.experienceLevel-1);
+        mcPlayer.addExperience(xpPoints);
+    }
+
+    @ZenMethod
     public static IActionResult<EnumActionResult> simulateRightClickItem(IPlayer player, IItemStack stack, @Optional IEntityEquipmentSlot hand) {
         return PlayerInteractionSimulation.simulateRightClickItem(player, stack, hand);
     }


### PR DESCRIPTION
Provide a way to manipulate player's xp points, rather than levels.
By simply calculating the target xp points in ZenScript then `set` it to the IPlayer object, more finely player experience manipulation is made possible.