### PR TITLE
Fix #34

### DIFF
--- a/src/main/java/youyihj/zenutils/api/world/ZenUtilsWorld.java
+++ b/src/main/java/youyihj/zenutils/api/world/ZenUtilsWorld.java
@@ -92,16 +92,22 @@ public class ZenUtilsWorld {
 
     @ZenMethod
     public static IData getCustomWorldData(IWorld world) {
-        return getWorldCap(world).getData();
+        IZenWorldCapability cap = getWorldCap(world);
+        if (cap == null) return null;
+        return cap.getData();
     }
 
     @ZenMethod
     public static void setCustomWorldData(IWorld world, IData data) {
-        getWorldCap(world).setData(data);
+        IZenWorldCapability cap = getWorldCap(world);
+        if (cap == null) return;
+        cap.setData(data);
     }
 
     @ZenMethod
     public static void updateCustomWorldData(IWorld world, IData data) {
+        IZenWorldCapability cap = getWorldCap(world);
+        if (cap == null) return;
         getWorldCap(world).updateData(data);
     }
 

--- a/src/main/java/youyihj/zenutils/impl/util/catenation/persistence/CatenationPersistenceImpl.java
+++ b/src/main/java/youyihj/zenutils/impl/util/catenation/persistence/CatenationPersistenceImpl.java
@@ -112,7 +112,9 @@ public class CatenationPersistenceImpl {
     }
 
     public static void loadCatenations(IWorld world) {
-        IData catenationsData = ZenUtilsWorld.getCustomWorldData(world).memberGet("catenations");
+        IData customWorldData = ZenUtilsWorld.getCustomWorldData(world);
+        if (customWorldData == null) return;
+        IData catenationsData = customWorldData.memberGet("catenations");
         if (catenationsData == null) return;
         for (IData catenationData : catenationsData.asList()) {
             Catenation catenation;


### PR DESCRIPTION
该 PR 所包含的修改能确保 #34 所述的崩溃现象不发生。
_______________
我猜测，假如维度加载总要执行 `loadCantenation`，要求 worldCap 中包含一个 `"catenation"` 键，那么将 worldCap 初始化成包含  `"catenation"` 键的非空状态，会不会比单纯地检查 null 并绕过更好？#34 或许有比我这里所给方案更好的解法。