### PR TITLE
Fix translation key when late-setting CoT function

### DIFF
--- a/src/main/java/youyihj/zenutils/impl/mixin/crafttweaker/MixinBlockContent.java
+++ b/src/main/java/youyihj/zenutils/impl/mixin/crafttweaker/MixinBlockContent.java
@@ -1,0 +1,22 @@
+package youyihj.zenutils.impl.mixin.crafttweaker;
+
+import net.minecraft.block.material.Material;
+
+import com.teamacronymcoders.base.blocks.BlockBase;
+import com.teamacronymcoders.contenttweaker.modules.vanilla.blocks.BlockContent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(value = BlockContent.class, remap = false)
+public abstract class MixinBlockContent extends BlockBase {
+    public MixinBlockContent(Material mat) {
+        super(mat);
+    }
+
+    @ModifyArg(method = "setFields", at = @At(value = "INVOKE", target = "Lcom/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent;setUnlocalizedName(Ljava/lang/String;)Lnet/minecraft/block/Block;", remap = true), index = 0)
+    private String fixTranslationKey(String original) {
+        if (this.getMod() == null || original.contains(this.getMod().getID())) return original;
+        return this.getMod().getID() + "." + original;
+    }
+}

--- a/src/main/java/youyihj/zenutils/impl/mixin/crafttweaker/MixinItemContent.java
+++ b/src/main/java/youyihj/zenutils/impl/mixin/crafttweaker/MixinItemContent.java
@@ -1,0 +1,20 @@
+package youyihj.zenutils.impl.mixin.crafttweaker;
+
+import com.teamacronymcoders.base.items.ItemBase;
+import com.teamacronymcoders.contenttweaker.modules.vanilla.items.ItemContent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(value = ItemContent.class, remap = false)
+public abstract class MixinItemContent extends ItemBase {
+    public MixinItemContent(String name) {
+        super(name);
+    }
+
+    @ModifyArg(method = "setFields", at = @At(value = "INVOKE", target = "Lcom/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemContent;setUnlocalizedName(Ljava/lang/String;)Lnet/minecraft/item/Item;", remap = true), index = 0)
+    private String fixTranslationKey(String original) {
+        if (this.getMod() == null || original.contains(this.getMod().getID())) return original;
+        return this.getMod().getID() + "." + original;
+    }
+}

--- a/src/main/resources/mixins.zenutils.json
+++ b/src/main/resources/mixins.zenutils.json
@@ -8,8 +8,10 @@
   "priority": 0,
   "refmap": "mixins.zenutils.refmap.json",
   "mixins": [
+    "MixinBlockContent",
     "MixinCoTItemBracketHandler",
     "MixinExpressionMap",
+    "MixinItemContent",
     "MixinMCEntity",
     "MixinMCPlayerAnvilUpdateEvent",
     "MixinParsedExpression",


### PR DESCRIPTION
Fixes #48 using mixins into CoT `BlockContent` and `ItemContent`. Feel free to accept or close PR if you have a better way to fix it.