### PR TITLE
Simple yet correct URI encoding

### DIFF
--- a/src/main/java/youyihj/zenutils/impl/zenscript/nat/MCPReobfuscation.java
+++ b/src/main/java/youyihj/zenutils/impl/zenscript/nat/MCPReobfuscation.java
@@ -79,7 +79,7 @@ public enum MCPReobfuscation {
                 throw new RuntimeException("Failed to download mcp mapping, try download it manually to `config/mcp_stable-39-1.12.zip`, uri: " + remoteMapping, e);
             }
         }
-        try (FileSystem zipFs = FileSystems.newFileSystem(URI.create("jar:file:" + encodeFilePath(localMapping.toUri().getPath())), Collections.emptyMap())) {
+        try (FileSystem zipFs = FileSystems.newFileSystem(URI.create("jar:" + localMapping.toUri().toASCIIString()), Collections.emptyMap())) {
             try (Stream<String> methodStream = Files.lines(zipFs.getPath("methods.csv"))) {
                 methodStream.skip(1)
                             .map(it -> it.split(","))
@@ -96,14 +96,4 @@ public enum MCPReobfuscation {
         return Pair.of(methodMap, fieldMap);
     }
 
-    private static String encodeFilePath(String filePath) throws UnsupportedEncodingException {
-        String encodedPath = filePath.replace("\\", "/");
-
-        encodedPath = URLEncoder.encode(encodedPath, "UTF-8")
-                .replace("+", "%20")
-                .replace("%2F", "/")
-                .replace("%3A", ":");
-
-        return encodedPath;
-    }
 }


### PR DESCRIPTION
on macOS (unix style path)
<img width="701" alt="image" src="https://github.com/user-attachments/assets/62ef71bc-9da7-42b2-94f3-ead8bd3a0b70">
on Windows
<img width="707" alt="image" src="https://github.com/user-attachments/assets/54734d5f-a47e-4242-bbff-63a76167dad5">
